### PR TITLE
standardize units: use GB for GPU nominal spec, GiB for actual memory…

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -284,6 +284,7 @@ Add new GPU models by editing `gpu_types.json`:
 {
   "name": "RTX 5090",
   "memory_gb": 32,
+  "memory_gib": 29.8,
   "category": "consumer",
   "architecture": "Blackwell"
 }

--- a/CONFIG_GUIDE.md
+++ b/CONFIG_GUIDE.md
@@ -9,7 +9,6 @@ The system uses three independent JSON configuration files:
 ### 1. `data_types.json` - Data Type Configuration
 
 Used to define bytes per parameter for different data types:
-
 ```json
 {
   "fp32": {
@@ -36,12 +35,14 @@ Used to define GPU models and specifications:
   {
     "name": "RTX 4090",
     "memory_gb": 24,
+    "memory_gib": 22.35,
     "category": "consumer",
     "architecture": "Ada Lovelace"
   },
   {
     "name": "Your Custom GPU",
     "memory_gb": 32,
+    "memory_gib": 29.8,
     "category": "custom",
     "architecture": "Custom Arch"
   }
@@ -113,6 +114,7 @@ python3 vram_calculator.py --dtype my_new_format microsoft/DialoGPT-medium
 {
   "name": "RTX 5090",
   "memory_gb": 32,
+  "memory_gib": 29.8,
   "category": "consumer",
   "architecture": "Blackwell"
 }
@@ -234,10 +236,10 @@ Focus on common research GPUs:
   "max_gpu_display": 5,
   "preferred_categories": ["datacenter"],
   "gpu_types": [
-    {"name": "V100 32GB", "memory_gb": 32, "category": "datacenter"},
-    {"name": "A100 40GB", "memory_gb": 40, "category": "datacenter"},
-    {"name": "A100 80GB", "memory_gb": 80, "category": "datacenter"},
-    {"name": "H100 80GB", "memory_gb": 80, "category": "datacenter"}
+    {"name": "V100 32GB", "memory_gb": 32, "memory_gib": 29.8, "category": "datacenter"},
+    {"name": "A100 40GB", "memory_gb": 40, "memory_gib": 37.25, "category": "datacenter"},
+    {"name": "A100 80GB", "memory_gb": 80, "memory_gib": 74.51, "category": "datacenter"},
+    {"name": "H100 80GB", "memory_gb": 80, "memory_gib": 74.51, "category": "datacenter"}
   ]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -301,22 +301,22 @@ The `--output_json` argument saves calculation results in a simplified JSON form
       "batch_size": 1,
       "sequence_length": 2048,
       "lora_rank": 64,
-      "model_size_gb": 6.75,
-      "kv_cache_size_gb": 0.13,
-      "inference_total_gb": 8.10,
-      "training_gb": 35.07,
-      "lora_size_gb": 8.37
+      "model_size_gib": 6.75,
+      "kv_cache_size_gib": 0.13,
+      "inference_total_gib": 8.10,
+      "training_gib": 35.07,
+      "lora_size_gib": 8.37
     },
     {
       "dtype": "BF16",
       "batch_size": 1,
       "sequence_length": 2048,
       "lora_rank": 64,
-      "model_size_gb": 13.49,
-      "kv_cache_size_gb": 0.25,
-      "inference_total_gb": 16.19,
-      "training_gb": 70.14,
-      "lora_size_gb": 16.73
+      "model_size_gib": 13.49,
+      "kv_cache_size_gib": 0.25,
+      "inference_total_gib": 16.19,
+      "training_gib": 70.14,
+      "lora_size_gib": 16.73
     }
   ]
 }

--- a/exps/gemma.json
+++ b/exps/gemma.json
@@ -13,11 +13,11 @@
       "batch_size": 1,
       "sequence_length": 2048,
       "lora_rank": 64,
-      "model_size_gb": 26.47,
-      "kv_cache_size_gb": 0.64,
-      "inference_total_gb": 31.76,
-      "training_gb": 137.63,
-      "lora_size_gb": 33.89
+      "model_size_gib": 26.47,
+      "kv_cache_size_gib": 0.64,
+      "inference_total_gib": 31.76,
+      "training_gib": 137.63,
+      "lora_size_gib": 33.89
     }
   ]
 }

--- a/exps/gpu_models.json
+++ b/exps/gpu_models.json
@@ -1,44 +1,51 @@
 {
-    "A100": {
-      "arch_family": "ampere",
-      "vram_gb": 80,
-      "fp8_support": false,
-      "bf16_support": true
-    },
-    "L40S": {
-      "arch_family": "ada",
-      "vram_gb": 46,
-      "fp8_support": false,
-      "bf16_support": true
-    },
-    "H20": {
-      "arch_family": "hopper",
-      "vram_gb": 96,
-      "fp8_support": true,
-      "bf16_support": true
-    },
-    "B200": {
-      "arch_family": "blackwell",
-      "vram_gb": 180,
-      "fp8_support": true,
-      "bf16_support": true
-    },
-    "L20": {
-      "arch_family": "blackwell",
-      "vram_gb": 46,
-      "fp8_support": false,
-      "bf16_support": true
-    },
-    "RTX6000SE": {
-      "arch_family": "ada",
-      "vram_gb": 48,
-      "fp8_support": false,
-      "bf16_support": true
-    },
-    "H100": {
-      "arch_family": "hopper",
-      "vram_gb": 80,
-      "fp8_support": true,
-      "bf16_support": true
-    }
+  "A100": {
+    "arch_family": "ampere",
+    "vram_gb": 80,
+    "fp8_support": false,
+    "bf16_support": true,
+    "vram_gib": 74.51
+  },
+  "L40S": {
+    "arch_family": "ada",
+    "vram_gb": 46,
+    "fp8_support": false,
+    "bf16_support": true,
+    "vram_gib": 42.84
+  },
+  "H20": {
+    "arch_family": "hopper",
+    "vram_gb": 96,
+    "fp8_support": true,
+    "bf16_support": true,
+    "vram_gib": 89.41
+  },
+  "B200": {
+    "arch_family": "blackwell",
+    "vram_gb": 180,
+    "fp8_support": true,
+    "bf16_support": true,
+    "vram_gib": 167.64
+  },
+  "L20": {
+    "arch_family": "blackwell",
+    "vram_gb": 46,
+    "fp8_support": false,
+    "bf16_support": true,
+    "vram_gib": 42.84
+  },
+  "RTX6000SE": {
+    "arch_family": "ada",
+    "vram_gb": 48,
+    "fp8_support": false,
+    "bf16_support": true,
+    "vram_gib": 44.7
+  },
+  "H100": {
+    "arch_family": "hopper",
+    "vram_gb": 80,
+    "fp8_support": true,
+    "bf16_support": true,
+    "vram_gib": 74.51
   }
+}

--- a/results.json
+++ b/results.json
@@ -13,11 +13,11 @@
       "batch_size": 4,
       "sequence_length": 4096,
       "lora_rank": 16,
-      "model_size_gb": 100.37,
-      "kv_cache_size_gb": 1.5,
-      "inference_total_gb": 120.44,
-      "training_gb": 521.92,
-      "lora_size_gb": 122.46
+      "model_size_gib": 100.37,
+      "kv_cache_size_gib": 1.5,
+      "inference_total_gib": 120.44,
+      "training_gib": 521.92,
+      "lora_size_gib": 122.46
     }
   ]
 }

--- a/src/hf_vram_calc/config.py
+++ b/src/hf_vram_calc/config.py
@@ -100,6 +100,9 @@ class ConfigManager:
         for gpu in gpu_types:
             if "name" not in gpu or "memory_gb" not in gpu:
                 raise ValueError(f"invalid GPU configuration: {gpu}")
+            # auto-calculate memory_gib if not present
+            if "memory_gib" not in gpu:
+                gpu["memory_gib"] = round(gpu["memory_gb"] * (1000**3 / 1024**3), 2)
 
         return gpu_types
 
@@ -126,10 +129,10 @@ class ConfigManager:
             for dtype, info in self.data_types.items()
         }
 
-    def get_gpu_types(self) -> List[Tuple[str, int, str]]:
-        """Get GPU types list with category"""
+    def get_gpu_types(self) -> List[Tuple[str, int, float, str]]:
+        """Get GPU types list with category and actual GiB memory"""
         return [
-            (gpu["name"], gpu["memory_gb"], gpu.get("category", "unknown"))
+            (gpu["name"], gpu["memory_gb"], gpu.get("memory_gib", gpu["memory_gb"] * 0.931323), gpu.get("category", "unknown"))
             for gpu in self.gpu_types
         ]
 

--- a/src/hf_vram_calc/gpu_types.json
+++ b/src/hf_vram_calc/gpu_types.json
@@ -1,231 +1,268 @@
 [
-
   {
     "name": "RTX 5090",
     "memory_gb": 32,
     "category": "consumer",
-    "architecture": "Blackwell"
+    "architecture": "Blackwell",
+    "memory_gib": 29.8
   },
   {
     "name": "RTX 5090D",
     "memory_gb": 32,
     "category": "consumer",
-    "architecture": "Blackwell"
+    "architecture": "Blackwell",
+    "memory_gib": 29.8
   },
   {
     "name": "RTX 5080",
     "memory_gb": 16,
     "category": "consumer",
-    "architecture": "Blackwell"
+    "architecture": "Blackwell",
+    "memory_gib": 14.9
   },
   {
     "name": "RTX 5070 Ti",
     "memory_gb": 16,
     "category": "consumer",
-    "architecture": "Blackwell"
+    "architecture": "Blackwell",
+    "memory_gib": 14.9
   },
   {
     "name": "RTX 5070",
     "memory_gb": 12,
     "category": "consumer",
-    "architecture": "Blackwell"
+    "architecture": "Blackwell",
+    "memory_gib": 11.18
   },
   {
     "name": "RTX 5060 Ti 16GB",
     "memory_gb": 16,
     "category": "consumer",
-    "architecture": "Blackwell"
+    "architecture": "Blackwell",
+    "memory_gib": 14.9
   },
   {
     "name": "RTX 5060 Ti 8GB",
     "memory_gb": 8,
     "category": "consumer",
-    "architecture": "Blackwell"
+    "architecture": "Blackwell",
+    "memory_gib": 7.45
   },
   {
     "name": "RTX 5060",
     "memory_gb": 8,
     "category": "consumer",
-    "architecture": "Blackwell"
+    "architecture": "Blackwell",
+    "memory_gib": 7.45
   },
   {
     "name": "RTX 5050",
     "memory_gb": 8,
     "category": "consumer",
-    "architecture": "Blackwell"
+    "architecture": "Blackwell",
+    "memory_gib": 7.45
   },
   {
     "name": "RTX 4090",
     "memory_gb": 24,
     "category": "consumer",
-    "architecture": "Ada Lovelace"
+    "architecture": "Ada Lovelace",
+    "memory_gib": 22.35
   },
   {
-    "name": "RTX 4080 Super", 
+    "name": "RTX 4080 Super",
     "memory_gb": 16,
     "category": "consumer",
-    "architecture": "Ada Lovelace"
+    "architecture": "Ada Lovelace",
+    "memory_gib": 14.9
   },
   {
     "name": "RTX 4080",
     "memory_gb": 16,
     "category": "consumer",
-    "architecture": "Ada Lovelace"
+    "architecture": "Ada Lovelace",
+    "memory_gib": 14.9
   },
   {
     "name": "RTX 4070 Ti Super",
     "memory_gb": 16,
     "category": "consumer",
-    "architecture": "Ada Lovelace"
+    "architecture": "Ada Lovelace",
+    "memory_gib": 14.9
   },
   {
     "name": "RTX 4070 Ti",
     "memory_gb": 12,
     "category": "consumer",
-    "architecture": "Ada Lovelace"
+    "architecture": "Ada Lovelace",
+    "memory_gib": 11.18
   },
   {
     "name": "RTX 4070 Super",
     "memory_gb": 12,
     "category": "consumer",
-    "architecture": "Ada Lovelace"
+    "architecture": "Ada Lovelace",
+    "memory_gib": 11.18
   },
   {
     "name": "RTX 4070",
     "memory_gb": 12,
     "category": "consumer",
-    "architecture": "Ada Lovelace"
+    "architecture": "Ada Lovelace",
+    "memory_gib": 11.18
   },
   {
     "name": "RTX 4060 Ti",
     "memory_gb": 16,
     "category": "consumer",
-    "architecture": "Ada Lovelace"
+    "architecture": "Ada Lovelace",
+    "memory_gib": 14.9
   },
   {
     "name": "RTX 3090 Ti",
     "memory_gb": 24,
     "category": "consumer",
-    "architecture": "Ampere"
+    "architecture": "Ampere",
+    "memory_gib": 22.35
   },
   {
     "name": "RTX 3090",
     "memory_gb": 24,
     "category": "consumer",
-    "architecture": "Ampere"
+    "architecture": "Ampere",
+    "memory_gib": 22.35
   },
   {
     "name": "RTX 3080 Ti",
     "memory_gb": 12,
     "category": "consumer",
-    "architecture": "Ampere"
+    "architecture": "Ampere",
+    "memory_gib": 11.18
   },
   {
     "name": "A100 40GB",
     "memory_gb": 40,
     "category": "datacenter",
-    "architecture": "Ampere"
+    "architecture": "Ampere",
+    "memory_gib": 37.25
   },
   {
     "name": "A100 80GB",
     "memory_gb": 80,
     "category": "datacenter",
-    "architecture": "Ampere"
+    "architecture": "Ampere",
+    "memory_gib": 74.51
   },
   {
     "name": "H100 80GB",
     "memory_gb": 80,
     "category": "datacenter",
-    "architecture": "Hopper"
+    "architecture": "Hopper",
+    "memory_gib": 74.51
   },
   {
     "name": "H200 141GB",
     "memory_gb": 141,
     "category": "datacenter",
-    "architecture": "Hopper"
+    "architecture": "Hopper",
+    "memory_gib": 131.32
   },
   {
     "name": "H20 96GB",
     "memory_gb": 96,
     "category": "datacenter",
-    "architecture": "Hopper"
+    "architecture": "Hopper",
+    "memory_gib": 89.41
   },
   {
     "name": "B100 192GB",
     "memory_gb": 192,
     "category": "datacenter",
-    "architecture": "Blackwell"
+    "architecture": "Blackwell",
+    "memory_gib": 178.81
   },
   {
     "name": "B200 192GB",
     "memory_gb": 192,
     "category": "datacenter",
-    "architecture": "Blackwell"
+    "architecture": "Blackwell",
+    "memory_gib": 178.81
   },
   {
     "name": "B300 288B",
     "memory_gb": 288,
     "category": "datacenter",
-    "architecture": "Blackwell"
+    "architecture": "Blackwell",
+    "memory_gib": 268.22
   },
   {
     "name": "GB300 288B",
     "memory_gb": 288,
     "category": "datacenter",
-    "architecture": "Blackwell"
+    "architecture": "Blackwell",
+    "memory_gib": 268.22
   },
   {
     "name": "A30",
     "memory_gb": 24,
     "category": "datacenter",
-    "architecture": "Ampere"
+    "architecture": "Ampere",
+    "memory_gib": 22.35
   },
   {
     "name": "A10",
     "memory_gb": 24,
     "category": "datacenter",
-    "architecture": "Ampere"
+    "architecture": "Ampere",
+    "memory_gib": 22.35
   },
   {
     "name": "V100 32GB",
     "memory_gb": 32,
     "category": "datacenter",
-    "architecture": "Volta"
+    "architecture": "Volta",
+    "memory_gib": 29.8
   },
   {
     "name": "T4",
     "memory_gb": 16,
     "category": "datacenter",
-    "architecture": "Turing"
+    "architecture": "Turing",
+    "memory_gib": 14.9
   },
   {
     "name": "L40S",
     "memory_gb": 48,
     "category": "datacenter",
-    "architecture": "Ada Lovelace"
+    "architecture": "Ada Lovelace",
+    "memory_gib": 44.7
   },
   {
     "name": "L40",
     "memory_gb": 48,
     "category": "datacenter",
-    "architecture": "Ada Lovelace"
+    "architecture": "Ada Lovelace",
+    "memory_gib": 44.7
   },
   {
     "name": "L4",
     "memory_gb": 24,
     "category": "datacenter",
-    "architecture": "Ada Lovelace"
+    "architecture": "Ada Lovelace",
+    "memory_gib": 22.35
   },
   {
     "name": "NVIDIA RTX PRO 6000 BLACKWELL",
     "memory_gb": 96,
     "category": "workstation",
-    "architecture": "Hopper"
+    "architecture": "Hopper",
+    "memory_gib": 89.41
   },
   {
     "name": "NVIDIA RTX PRO 5000 BLACKWELL",
     "memory_gb": 48,
     "category": "workstation",
-    "architecture": "Hopper"
+    "architecture": "Hopper",
+    "memory_gib": 44.7
   }
 ]

--- a/tools/README.md
+++ b/tools/README.md
@@ -48,10 +48,10 @@ python tools/decider.py --gpu_model L40S --num_gpus 2 --model google/gemma-3-27b
     "dtype": "FP8"
   },
   "calc": {
-    "memory_estimate_gb": 26.47,
-    "gpu_vram_gb": 46.0,
-    "per_gpu_required_gb": 13.23,
-    "ratio": 0.2877,
+    "memory_estimate_gib": 26.47,
+    "gpu_vram_gib": 42.84,
+    "per_gpu_required_gib": 13.23,
+    "ratio": 0.3087,
     "dtype_used": "FP8"
   }
 }

--- a/tools/decider.py
+++ b/tools/decider.py
@@ -1,5 +1,5 @@
 """
-Minimal decider: use model_size_gb from hf-vram-calc JSON (or provided file),
+Minimal decider: use model_size_gib from hf-vram-calc JSON (or provided file),
 compare to GPU VRAM with simple per-GPU ratio. No complex rules or exceptions.
 """
 
@@ -85,14 +85,14 @@ def prepare_from_cli(args: argparse.Namespace) -> tuple[Dict[str, Any], Dict[str
     return inputs, mem_entry, hf_json
 
 
-def compute_calc(mem_entry: Dict[str, Any], vram_gb: float, num_gpus: int) -> Dict[str, Any]:
-    model_size_gb = float(mem_entry["model_size_gb"])  # assume present
-    per_gpu_required = model_size_gb / max(1, int(num_gpus))
-    ratio = per_gpu_required / float(vram_gb)
+def compute_calc(mem_entry: Dict[str, Any], vram_gib: float, num_gpus: int) -> Dict[str, Any]:
+    model_size_gib = float(mem_entry["model_size_gib"])  # assume present
+    per_gpu_required = model_size_gib / max(1, int(num_gpus))
+    ratio = per_gpu_required / float(vram_gib)
     return {
-        "memory_estimate_gb": round(model_size_gb, 2),
-        "gpu_vram_gb": float(vram_gb),
-        "per_gpu_required_gb": round(per_gpu_required, 2),
+        "memory_estimate_gib": round(model_size_gib, 2),
+        "gpu_vram_gib": float(vram_gib),
+        "per_gpu_required_gib": round(per_gpu_required, 2),
         "ratio": round(ratio, 4),
         "dtype_used": mem_entry.get("dtype"),
     }
@@ -126,8 +126,8 @@ def main() -> None:
             return
         inputs, mem_entry, hf_json = prepare_from_cli(args)
 
-    # Compute
-    calc = compute_calc(mem_entry, float(gpu_caps["vram_gb"]), inputs["num_gpus"])
+    # Compute (use vram_gib for accurate calculation)
+    calc = compute_calc(mem_entry, float(gpu_caps["vram_gib"]), inputs["num_gpus"])
     decision = decide(calc["ratio"])
 
     out = {"decision": decision, "inputs": inputs, "calc": calc}


### PR DESCRIPTION
 standardize units: use GB for GPU nominal spec, GiB for actual memory, internal calculations, model size, outputs, and rename JSON fields from _gb to _gib